### PR TITLE
Implement Asynchronous Scroll and Add Randomness to Stream Speeds

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ pub struct Config {
     pub stream_spacing: u16,
 
     /// Frame-Rate
-    #[clap(long, default_value = "15")]
+    #[clap(long, default_value = "60")]
     pub fps: u64,
 
     /// Character Symbol Set

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -39,11 +39,11 @@ impl FromStr for Mode {
 /// Represents a single entity in the matrix-stream
 pub struct Entity {
     /// x position
-    pub x: i32,
+    pub x: f32,
     /// y position
-    pub y: i32,
+    pub y: f32,
     /// rain-fall speed
-    speed: i32,
+    speed: f32,
     /// entity color
     color: ansi::RGBColor,
     /// entity symbol
@@ -58,7 +58,7 @@ pub struct Entity {
 
 impl Entity {
     /// Entity constructor
-    pub fn new(x: i32, y: i32, speed: i32, config: &config::Config) -> Self {
+    pub fn new(x: f32, y: f32, speed: f32, config: &config::Config) -> Self {
         return Self {
             x,
             y,
@@ -71,7 +71,7 @@ impl Entity {
         };
     }
 
-    pub fn new_leader(x: i32, y: i32, speed: i32, config: &config::Config) -> Self {
+    pub fn new_leader(x: f32, y: f32, speed: f32, config: &config::Config) -> Self {
         return Self {
             x,
             y,
@@ -121,7 +121,7 @@ impl Entity {
     /// Render entity on screen
     pub fn render(&mut self) {
         //  Don't render if y is above screen
-        if self.y < 0 {
+        if self.y < 0.0 {
             return;
         }
 
@@ -139,7 +139,7 @@ impl Entity {
     /// Cleans the last position of this entity
     pub fn clean(&self, rows: u32) {
         let last_y = self.y - self.speed;
-        if last_y <= 0 {
+        if last_y <= 0.0 {
             ansi::cursor_move_to(rows, self.x as u32)
         } else {
             ansi::cursor_move_to(last_y as u32, self.x as u32);

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -35,7 +35,7 @@ impl Matrix {
             }
             //  Generate the stream
             let height_offset = utils::random_between(-50, 0);
-            let stream = Stream::new(c as i32, height_offset, config);
+            let stream = Stream::new(c as f32, height_offset as f32, config);
 
             //  Add stream to vector collection
             ret.streams.push(stream);

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -13,12 +13,12 @@ pub struct Stream {
     pub entities: Vec<Entity>,
 
     // X Position
-    x: i32,
+    x: f32,
     // Y Position
-    y: i32,
+    y: f32,
 
     /// Speed
-    speed: i32,
+    speed: f32,
 
     /// Count of entities
     count: u16,
@@ -26,12 +26,12 @@ pub struct Stream {
 
 impl Stream {
     /// Construct new stream
-    pub fn new(x: i32, y: i32, config: &config::Config) -> Self {
+    pub fn new(x: f32, y: f32, config: &config::Config) -> Self {
         let mut stream = Stream {
             entities: Vec::new(),
             x,
             y,
-            speed: 1,
+            speed: utils::random_between(0.125, 1.0),
             count: utils::random_between(config.stream_min_count, config.stream_max_count),
         };
         stream.generate_entities(config);
@@ -49,7 +49,7 @@ impl Stream {
 
         // Create the following entities
         for i in 1..self.count {
-            let mut e = Entity::new(self.x, self.y - i as i32, self.speed, config);
+            let mut e = Entity::new(self.x, self.y - i as f32, self.speed, config);
             e.set_symbol();
             self.entities.push(e);
         }
@@ -70,7 +70,7 @@ impl Stream {
                 e.clean(rows as u32);
                 // Regenerate the stream and place it at the top if the last entity is off the screen
                 // (i.e. the y position is greater than the number of rows).
-                if e.y >= rows {
+                if e.y >= rows as f32 {
                     self.generate_entities(&config);
                 }
             }


### PR DESCRIPTION
This pull request implements asynchronous scroll functionality and adds randomness to the stream speeds in the codebase. The changes include setting up variable speed for asynchronous scroll and setting the default frames per second (fps) to 60. Additionally, the entity positions and speeds have been changed from integers to floats to allow for smoother scrolling. The Stream and Entity structs have been updated accordingly. This PR fixes issue #28.