### PR TITLE
Hide/Show cursor when entering/exiting alt-screen

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -16,6 +16,16 @@ pub fn cursor_move_to(r: u32, c: u32) {
     print!("\u{001b}[{};{}H", r, c);
 }
 
+// Hide the cursor
+pub fn hide_cursor() {
+    print!("\u{001b}[?25l");
+}
+
+// Show the cursor
+pub fn show_cursor() {
+    print!("\u{001b}[?25h");
+}
+
 // RGB COLOR
 // ---------
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ fn main() {
 
     //  Render the Matrix-Rain on screen
     ansi::clear_screen();
+    ansi::hide_cursor();
     loop {
         // Check if 'q' or Ctrl+C has been pressed
         if event::poll(Duration::from_millis(0)).unwrap() {
@@ -51,5 +52,6 @@ fn main() {
     //  Clear screen and disable raw mode before exiting
     ansi::clear_screen();
     ansi::cursor_move_to(0, 0);
+    ansi::show_cursor();
     terminal::disable_raw_mode().unwrap();
 }


### PR DESCRIPTION
This pull request adds functionality to hide and show the cursor when entering and exiting the alt-screen. This improves the user experience by providing a cleaner interface. Fixes #33.