### PR TITLE
Make Entity `switch_interval` configurable

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -38,10 +38,10 @@ pub struct Config {
     #[clap(long, default_value = "2")]
     pub stream_spacing: u16,
 
-    /// The max number-of-frames within which an entity randomly switches it's symbol.
+    /// The max number-of-seconds within which an entity randomly switches it's symbol.
     ///
     /// This adds a bit of randomness to each stream, as the entities can switch their
     /// symbol as they rain down the screen.
-    #[clap(long, default_value = "60")]
+    #[clap(long, default_value = "1")]
     pub switch_interval: u16,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,4 +37,11 @@ pub struct Config {
     /// Stream Spacing
     #[clap(long, default_value = "2")]
     pub stream_spacing: u16,
+
+    /// The max number-of-frames within which an entity randomly switches it's symbol.
+    ///
+    /// This adds a bit of randomness to each stream, as the entities can switch their
+    /// symbol as they rain down the screen.
+    #[clap(long, default_value = "60")]
+    pub switch_interval: u16,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,9 +22,9 @@ pub struct Config {
     #[clap(long, default_value = "200,255,200")]
     pub leading_entity_color: ansi::RGBColor,
 
-    /// Frame-Rate
+    /// The Frame-Rate to run at. The screen will rerender this many times each second.
     #[clap(long, default_value = "60")]
-    pub fps: u64,
+    pub fps: u16,
 
     /// Minimum number of entities per stream
     #[clap(long, default_value = "5")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn run(config: &config::Config) -> std::io::Result<()> {
         matrix.render(&config, &mut stdout)?;
 
         // Handle events
-        if crossterm::event::poll(std::time::Duration::from_millis(1000 / config.fps))? {
+        if crossterm::event::poll(std::time::Duration::from_millis(1000 / config.fps as u64))? {
             if let events::Action::Exit = events::handle_events()? {
                 break;
             }

--- a/src/matrix/entity.rs
+++ b/src/matrix/entity.rs
@@ -49,7 +49,7 @@ impl Entity {
             symbol: ' ',
             mode: config.mode.clone(),
             frame_count: 0,
-            switch_interval: utils::random_between::<u16>(1, 60),
+            switch_interval: utils::random_between::<u16>(1, config.switch_interval),
         }
     }
 

--- a/src/matrix/entity.rs
+++ b/src/matrix/entity.rs
@@ -49,7 +49,7 @@ impl Entity {
             symbol: ' ',
             mode: config.mode.clone(),
             frame_count: 0,
-            switch_interval: utils::random_between::<u16>(1, config.switch_interval),
+            switch_interval: utils::random_between::<u16>(1, config.switch_interval * config.fps),
         }
     }
 


### PR DESCRIPTION
This allows the user to pass in the entity `switch_interval` as a command-line argument